### PR TITLE
Immediate part in B-type commands.

### DIFF
--- a/src/sr_cpu.v
+++ b/src/sr_cpu.v
@@ -145,7 +145,8 @@ module sr_decode
         immB[    0] = 1'b0;
         immB[ 4: 1] = instr[11:8];
         immB[10: 5] = instr[30:25];
-        immB[31:11] = { 21 {instr[31]} };
+        immB[   11] = instr[7];
+        immB[31:12] = { 20 {instr[31]} };
     end
 
     // U-immediate


### PR DESCRIPTION
Lost one bit immediate part in instructions decoder for B-type commands.

![RISCV_SPEC](https://user-images.githubusercontent.com/40476180/94985658-207d9600-0561-11eb-925b-eb985b9275cd.png)

![2020-10-03_10-38-15 (2)](https://user-images.githubusercontent.com/40476180/94986168-2a08fd00-0565-11eb-853b-376fa22e3039.png)
